### PR TITLE
Fix MaryUI tabs styling with daisyUI >= 5.6.5

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -505,6 +505,14 @@
     .tab-content {
         padding: 0px !important;
     }
+
+    /* MaryUI tabs fix (daisyUI >= 5.6.5, #4595) : restaure le style de base des
+       labels `.tab` que daisyUI a déplacé derrière `.tabs > .tab`. Dans
+       @layer components (PAS non-layered) pour que les utilitaires priment. */
+    .tab {
+        @apply hover:text-base-content relative inline-flex cursor-pointer appearance-none flex-wrap items-center justify-center text-center select-none;
+        font-size: 0.875rem;
+    }
 }
 
 @layer utilities {
@@ -520,6 +528,12 @@
             background-color: var(--color-secondary) !important;
         }
     }
+}
+
+/* MaryUI tabs fix (daisyUI >= 5.6.5, #4595) : ré-affiche le panneau actif.
+   Non-layered pour l'emporter sur le `.tab-content { display:none }` de daisyUI. */
+.tab:is(.tab-active, [aria-selected="true"], [aria-current="true"], [aria-current="page"]) + .tab-content {
+    display: block;
 }
 
 /* Root variables and utilities */


### PR DESCRIPTION
## Summary
This PR fixes tab styling issues in MaryUI when using daisyUI version 5.6.5 or later. The changes restore proper tab appearance and visibility that were affected by daisyUI's CSS layer reorganization.

## Key Changes
- Added `.tab` component styles within the `@layer components` to restore base styling for tab labels (hover states, layout, sizing)
- Added non-layered CSS rule to ensure active tab content displays correctly by overriding daisyUI's `display:none` rule
- Supports multiple active tab selectors: `.tab-active`, `[aria-selected="true"]`, `[aria-current="true"]`, and `[aria-current="page"]`

## Implementation Details
- The `.tab` styles are placed in the components layer to allow utility classes to override them as needed
- The active tab-content display rule is intentionally non-layered to guarantee it takes precedence over daisyUI's layered styles
- Both fixes are documented with comments referencing issue #4595 and the affected daisyUI version

https://claude.ai/code/session_0138GPg1k8BvHJJF2iXFKmba