### PR TITLE
Register mary-badge component alias in AppServiceProvider

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Mary\View\Components\Badge;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +21,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        // MaryUI >= 2.9.2 (PR robsontenorio/mary#1099): the <x-tab> template renders
+        // its internal badge as <x-mary-badge>, but MaryServiceProvider never registers
+        // a "mary-badge" alias (the badge is only bound to the configurable prefix, i.e.
+        // <x-badge> with the default empty prefix). Since Blade resolves <x-...> tags at
+        // compile time — before the badge's @if — any page containing an <x-tab> would
+        // throw "Unable to locate a class or view for component [mary-badge]". We register
+        // the missing alias here so tabs keep working across the 2.9.x range.
+        Blade::component('mary-badge', Badge::class);
     }
 }


### PR DESCRIPTION
## Summary

Registers the missing `mary-badge` component alias in the `boot()` method of `AppServiceProvider` to resolve a compatibility issue with MaryUI >= 2.9.2.

## Problem

MaryUI 2.9.2+ changed the `<x-tab>` component template to render its internal badge as `<x-mary-badge>`, but `MaryServiceProvider` only registers the badge component under the configurable prefix (e.g., `<x-badge>` with the default empty prefix). Since Blade resolves component tags at compile time, any page containing `<x-tab>` would throw:

```
Unable to locate a class or view for component [mary-badge]
```

## Solution

- Added `use` statements for `Blade` facade and `Badge` component class
- Registered the `mary-badge` alias explicitly in the `boot()` method via `Blade::component('mary-badge', Badge::class)`

This ensures the tab component's internal badge reference resolves correctly across the 2.9.x range while MaryUI's upstream issue is addressed.

https://claude.ai/code/session_0178tB19rGPstdBtFqmMLEm4