### PR TITLE
Upgrade MaryUI to ^2.9.5 and remove mary-badge workaround

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,9 +2,7 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
-use Mary\View\Components\Badge;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -21,13 +19,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        // MaryUI >= 2.9.2 (PR robsontenorio/mary#1099): the <x-tab> template renders
-        // its internal badge as <x-mary-badge>, but MaryServiceProvider never registers
-        // a "mary-badge" alias (the badge is only bound to the configurable prefix, i.e.
-        // <x-badge> with the default empty prefix). Since Blade resolves <x-...> tags at
-        // compile time — before the badge's @if — any page containing an <x-tab> would
-        // throw "Unable to locate a class or view for component [mary-badge]". We register
-        // the missing alias here so tabs keep working across the 2.9.x range.
-        Blade::component('mary-badge', Badge::class);
+        //
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0",
         "livewire/livewire": "^4.0",
-        "robsontenorio/mary": "^2.9.1",
+        "robsontenorio/mary": "^2.9.5",
         "spatie/laravel-sitemap": "^8.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "976bab533d3b8a590a16a8f80d17652b",
+    "content-hash": "7f4c4eebc6dfd5f7acdebb194ccd41fd",
     "packages": [
         {
             "name": "artesaos/seotools",
@@ -3913,16 +3913,16 @@
         },
         {
             "name": "robsontenorio/mary",
-            "version": "2.9.3",
+            "version": "2.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/robsontenorio/mary.git",
-                "reference": "a2e25107ca4a165394c7903b42cd955d3ef4925f"
+                "reference": "cb8107008376ce45a21aec9029333212f47a4616"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/robsontenorio/mary/zipball/a2e25107ca4a165394c7903b42cd955d3ef4925f",
-                "reference": "a2e25107ca4a165394c7903b42cd955d3ef4925f",
+                "url": "https://api.github.com/repos/robsontenorio/mary/zipball/cb8107008376ce45a21aec9029333212f47a4616",
+                "reference": "cb8107008376ce45a21aec9029333212f47a4616",
                 "shasum": ""
             },
             "require": {
@@ -3987,7 +3987,7 @@
             ],
             "support": {
                 "issues": "https://github.com/robsontenorio/mary/issues",
-                "source": "https://github.com/robsontenorio/mary/tree/2.9.3"
+                "source": "https://github.com/robsontenorio/mary/tree/2.9.5"
             },
             "funding": [
                 {
@@ -3995,7 +3995,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-10T15:57:52+00:00"
+            "time": "2026-07-17T12:41:47+00:00"
         },
         {
             "name": "spatie/crawler",
@@ -10537,5 +10537,5 @@
         "php": "^8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary

Upgrades the MaryUI dependency from `^2.9.1` to `^2.9.5` and removes the temporary workaround that was registered in `AppServiceProvider::boot()` to handle a missing `mary-badge` component alias.

## Changes

- **Dependency upgrade:** `robsontenorio/mary` bumped from `^2.9.1` to `^2.9.5`
- **Removed workaround code:** Deleted the `Blade::component('mary-badge', Badge::class)` registration and its explanatory comment from `AppServiceProvider::boot()`
- **Cleanup:** Removed now-unused imports (`Blade` facade and `Badge` class)

## Details

The workaround was a temporary fix for MaryUI ≥ 2.9.2, where the `<x-tab>` component template rendered an internal badge as `<x-mary-badge>`, but the MaryServiceProvider did not register a `mary-badge` alias. This caused Blade compilation to fail on any page containing tabs.

Version 2.9.5 resolves this issue upstream, so the manual alias registration is no longer needed. The code is now cleaner and relies on MaryUI's own component registration.

https://claude.ai/code/session_01T4c8vqE4VUyKcRTPJsfPoW