### PR TITLE
Fix tab-content border styling in MaryUI 2.9 tabs

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -506,6 +506,10 @@
 
     .tab-content {
         padding: 0px !important;
+        /* MaryUI 2.9 code en dur `border-t-base-content/10` sur chaque .tab-content ;
+           daisyUI en fournit la largeur -> ligne pleine largeur au-dessus du panneau.
+           Neutraliser la largeur du bord supérieur (couleur seule ne suffit pas). */
+        border-top: 0 !important;
     }
 
     /* MaryUI 2.9 code en dur un conteneur `tabs tabs-border` ; neutraliser la barre animée de 3px */


### PR DESCRIPTION
## Summary

Removes the hardcoded top border from `.tab-content` elements that MaryUI 2.9 applies via `border-t-base-content/10`. This border was rendering as a full-width line above each tab panel, which was not the intended design.

## Changes

- **`resources/css/app.css`**: Added `border-top: 0 !important;` to the `.tab-content` rule to neutralize the border width (color alone was insufficient). Included an explanatory comment documenting that MaryUI 2.9 hardcodes this border and daisyUI provides its width, resulting in an unwanted full-width line above the panel.

## Implementation Details

This is a targeted CSS override following the existing pattern in the file (see the comment below about the animated 3px bar). The `!important` flag is necessary because MaryUI applies the border inline or with high specificity. The fix preserves all other `.tab-content` styling while only removing the problematic border.

https://claude.ai/code/session_01Y4NeDoFqfZ7RBsByzMEDnc