### PR TITLE
fix(css): responsive vertical safe zone for modals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,18 @@ set in `config/livewire.php`). Reusable Blade components are in `resources/views
 - **`resources/css/app.css` keeps two `@source` lines** for `vendor/.../Pagination` and
   `storage/framework/views` (Tailwind auto-detection skips gitignored paths). Removing
   them breaks MaryUI table paginators. This is intentional — see `LARAVEL13_MIGRATION.md` §5.5.
+- **Modal safe-zone CSS** (end of `app.css`, ported from the Laravel-modernStart starter
+  kit) sits **outside every `@layer` on purpose** — non-layered CSS wins over the
+  daisyUI/Tailwind layers, so no `!important` is needed. It sizes `.modal` with `100dvh`
+  + `env(safe-area-inset-*)` and pins the close `X` and `.modal-action` bar with
+  `position: sticky`, so tall modals stay usable on mobile/short-landscape viewports.
+  The sticky offsets are deliberately "scrollport minus padding" (`top: 0` on the form,
+  `bottom: calc(var(--modal-box-p) * -1)` on the action bar) — do not "fix" them to
+  `var(--modal-box-p)`. If a modal overrides `.modal-box` padding via `box-class`
+  (`p-4`, `p-8`…), set `--modal-box-p` to match on that modal
+  (e.g. `class="[--modal-box-p:1rem]"`), otherwise the `X` and the action-bar background
+  shift by the delta. Note this also overrides `max-h-*` utilities passed in `box-class`
+  (`max-h-9/10` → the safe area), which is intended.
 - **daisyUI themes** are defined inline in `app.css`. If you rename a theme, also update
   `resources/js/theme-store.js` and `resources/views/partials/theme-init-script.blade.php`.
 - **Icons** use the `phosphor.*` prefix (blade-phosphor-icons), e.g. `phosphor.shield-warning`.

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -556,3 +556,79 @@ main {
 /**
 * Custom CSS
 */
+
+/* ============================================
+   MODALS - RESPONSIVE VERTICAL SAFE ZONE
+   ============================================
+
+   daisyUI dimensionne .modal-box avec max-h-screen (100vh) et clippe .modal
+   (overflow: clip). Sur mobile/tablette, 100vh = viewport « large » (barre d'URL
+   rétractée) : une modale haute déborde sous la chrome du navigateur sans pouvoir
+   scroller -> bouton X et actions inatteignables. Les safe areas OS (encoche,
+   home indicator) ne sont pas prises en compte non plus.
+
+   Ce bloc est volontairement HORS de tout @layer : le CSS non-layered l'emporte
+   sur les couches daisyUI/Tailwind, donc aucun !important n'est nécessaire.
+
+   Notes :
+   - Si une modale passe un padding custom via box-class (p-4, p-8...), aligner
+     --modal-box-p dessus sur cette modale (ex. class="[--modal-box-p:1rem]"),
+     sinon le X et le fond de la barre d'actions seront décalés du delta.
+   - Les offsets sticky sont calculés « scrollport moins padding » : ne pas
+     « corriger » top: 0 en top: var(--modal-box-p), ça descendrait le X d'un
+     padding entier.
+   - background-color: inherit sur la barre d'actions suit un fond custom passé
+     en box-class ; ne pas le figer sur base-100.
+   ============================================ */
+:root {
+    --modal-safe-block: 1rem;
+    --modal-safe-inline: 0.75rem;
+    --modal-box-p: 1.5rem; /* doit refléter le padding de .modal-box (p-6) */
+}
+
+.modal {
+    height: 100vh; /* fallback */
+    height: 100dvh;
+    padding-top: max(var(--modal-safe-block), env(safe-area-inset-top, 0px));
+    padding-bottom: max(var(--modal-safe-block), env(safe-area-inset-bottom, 0px));
+    padding-left: max(var(--modal-safe-inline), env(safe-area-inset-left, 0px));
+    padding-right: max(var(--modal-safe-inline), env(safe-area-inset-right, 0px));
+}
+
+.modal .modal-box {
+    max-height: 100%;
+    -webkit-overflow-scrolling: touch;
+}
+
+.modal-box > form[method="dialog"] {
+    position: sticky;
+    top: 0;
+    z-index: 999;
+    height: 0;
+}
+
+.modal-box > form[method="dialog"] .btn {
+    top: calc(0.5rem - var(--modal-box-p));
+    inset-inline-end: calc(0.5rem - var(--modal-box-p));
+}
+
+.modal-box > .modal-action {
+    position: sticky;
+    bottom: calc(var(--modal-box-p) * -1);
+    z-index: 998;
+    margin-top: 0.75rem;
+    margin-inline: calc(var(--modal-box-p) * -1);
+    margin-bottom: calc(var(--modal-box-p) * -1);
+    padding: 0.75rem var(--modal-box-p) var(--modal-box-p);
+    background-color: inherit;
+    border-end-start-radius: inherit;
+    border-end-end-radius: inherit;
+}
+
+.modal-bottom { padding-bottom: 0; padding-left: 0; padding-right: 0; }
+.modal-bottom .modal-box { padding-bottom: calc(var(--modal-box-p) + env(safe-area-inset-bottom, 0px)); }
+.modal-top { padding-top: 0; padding-left: 0; padding-right: 0; }
+.modal-top .modal-box { padding-top: calc(var(--modal-box-p) + env(safe-area-inset-top, 0px)); }
+.modal-start, .modal-end { padding-top: 0; padding-bottom: 0; }
+.modal-start { padding-inline-start: 0; }
+.modal-end { padding-inline-end: 0; }


### PR DESCRIPTION
daisyUI sizes .modal-box with max-h-screen (100vh) and clips .modal with
overflow: clip. On mobile/tablet 100vh is the "large" viewport (URL bar
retracted), so a tall modal overflows under the browser chrome and, since
the overflow is clipped rather than scrollable, the close and confirm
buttons become unreachable. OS safe areas (notch, home indicator, gesture
bar) were not accounted for either.

Port the generic fix from the Laravel-modernStart starter kit:

- size .modal with 100dvh (100vh fallback) and pad it with
  max(safe-block/inline, env(safe-area-inset-*))
- cap .modal-box at 100% of that safe area so it scrolls instead of clipping
- pin the close X (form[method="dialog"]) and the .modal-action bar with
  position: sticky, using scrollport-minus-padding offsets so they keep
  their exact daisyUI resting position
- keep the modal-top/bottom/start/end edge variants flush

The block is deliberately outside every @layer: non-layered CSS wins over
the daisyUI/Tailwind layers, so no !important is required. No Blade
component is touched — the rules apply to every modal, MaryUI or raw
daisyUI.

Verified with npm run build plus a Chromium harness using MaryUI's modal
markup at 390x720, 820x1000 and 740x360: short modals keep byte-identical
vertical spacing and button positions, long modals keep the X and the
action buttons visible at every scroll position (previously the X scrolled
out of reach).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KRzA2k5RfBf4BEV3wd6Y7G