### PR TITLE
Add ARIA tabs accessibility shim for MaryUI >= 2.9.9

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2563,16 +2563,16 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v4.3.3",
+            "version": "v4.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "8021f2561865c4c297a3bfca37212a99034377e7"
+                "reference": "7ef4b2a876c71744e86463079dd506b26eeab624"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/8021f2561865c4c297a3bfca37212a99034377e7",
-                "reference": "8021f2561865c4c297a3bfca37212a99034377e7",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/7ef4b2a876c71744e86463079dd506b26eeab624",
+                "reference": "7ef4b2a876c71744e86463079dd506b26eeab624",
                 "shasum": ""
             },
             "require": {
@@ -2627,7 +2627,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v4.3.3"
+                "source": "https://github.com/livewire/livewire/tree/v4.3.5"
             },
             "funding": [
                 {
@@ -2635,7 +2635,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-27T03:16:11+00:00"
+            "time": "2026-08-03T04:09:44+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -3913,16 +3913,16 @@
         },
         {
             "name": "robsontenorio/mary",
-            "version": "2.9.5",
+            "version": "2.9.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/robsontenorio/mary.git",
-                "reference": "cb8107008376ce45a21aec9029333212f47a4616"
+                "reference": "d02c03f54e16d28288cf26c15f33a8c18debd33e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/robsontenorio/mary/zipball/cb8107008376ce45a21aec9029333212f47a4616",
-                "reference": "cb8107008376ce45a21aec9029333212f47a4616",
+                "url": "https://api.github.com/repos/robsontenorio/mary/zipball/d02c03f54e16d28288cf26c15f33a8c18debd33e",
+                "reference": "d02c03f54e16d28288cf26c15f33a8c18debd33e",
                 "shasum": ""
             },
             "require": {
@@ -3987,7 +3987,7 @@
             ],
             "support": {
                 "issues": "https://github.com/robsontenorio/mary/issues",
-                "source": "https://github.com/robsontenorio/mary/tree/2.9.5"
+                "source": "https://github.com/robsontenorio/mary/tree/2.9.9"
             },
             "funding": [
                 {
@@ -3995,7 +3995,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-17T12:41:47+00:00"
+            "time": "2026-07-29T22:01:59+00:00"
         },
         {
             "name": "spatie/crawler",
@@ -10537,5 +10537,5 @@
         "php": "^8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,2 +1,3 @@
+import './tabs-a11y';
 import './theme-store';
 import './x-anchor-fix';

--- a/resources/js/tabs-a11y.js
+++ b/resources/js/tabs-a11y.js
@@ -1,0 +1,353 @@
+/**
+ * Tabs Accessibility Shim - MaryUI >= 2.9.9
+ *
+ * MaryUI 2.9.9 rewrote <x-tab> around x-teleport and dropped the hidden
+ * <input type="radio"> that every tab label used to wrap, replacing it with a
+ * bare @click handler. The rendered labels therefore carry no tabindex, no
+ * role and no aria-selected, and hold no focusable element at all: the tabs
+ * became mouse-only - unreachable by keyboard and opaque to screen readers.
+ * MaryUI <= 2.9.8 is NOT affected and is left strictly untouched.
+ *
+ * This module re-layers the WAI-ARIA tabs pattern on top of the rendered
+ * markup, without patching vendor components, Blade views or CSS:
+ * - role=tablist / role=tab / role=tabpanel, plus the id wiring between them,
+ * - aria-selected and a roving tabindex derived from the `tab-active` class
+ *   MaryUI already toggles (the selection state is never duplicated here),
+ * - ArrowLeft / ArrowRight / Home / End / Enter / Space handling.
+ *
+ * Activation always goes through label.click(), so MaryUI's own Alpine handler
+ * remains the single owner of the selection. No class and no visual output is
+ * changed - daisyUI's `.tab:focus-visible` outline appears on its own as soon
+ * as a label becomes focusable.
+ */
+
+// Marks a container whose listeners and observers are already attached.
+const CONTAINER_FLAG = 'data-tabs-a11y';
+
+// Marks the labels and panels enhanced by this module.
+const TAB_FLAG = 'data-tabs-a11y-tab';
+const PANEL_FLAG = 'data-tabs-a11y-panel';
+
+// Keys handled on the tablist. preventDefault() is called for these only.
+const NAV_KEYS = ['ArrowLeft', 'ArrowRight', 'Home', 'End', 'Enter', ' ', 'Spacebar'];
+
+// Matches the tab name inside an Alpine expression: `selected = 'tours'` on a
+// label (@click) and `selected == 'tours'` on a panel (x-show).
+const NAME_PATTERN = /selected\s*={1,3}\s*(['"])([\s\S]*?)\1/;
+
+let sequence = 0;
+
+/**
+ * Read the tab name a label assigns, from any @click / x-on:click attribute.
+ * Alpine leaves those attributes in the DOM, so they can be parsed back.
+ */
+function labelName(label) {
+    for (const attribute of label.attributes) {
+        if (!attribute.name.startsWith('@click') && !attribute.name.startsWith('x-on:click')) {
+            continue;
+        }
+
+        const match = attribute.value.match(NAME_PATTERN);
+
+        if (match) {
+            return match[2];
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Read the tab name a panel is bound to, from its x-show expression.
+ */
+function panelName(panel) {
+    const match = (panel.getAttribute('x-show') || '').match(NAME_PATTERN);
+
+    return match ? match[2] : null;
+}
+
+/**
+ * True when a label is already keyboard-operable on its own. MaryUI <= 2.9.8
+ * wrapped every label in a hidden radio input, and a future upstream fix may
+ * ship its own roles - in both cases this module must stay out of the way.
+ */
+function isOperable(label) {
+    return label.hasAttribute('tabindex')
+        || label.getAttribute('role') === 'tab'
+        || label.querySelector('input, button, a, [tabindex]') !== null;
+}
+
+/**
+ * Turn an arbitrary tab name into an id-safe fragment.
+ */
+function idSafe(value) {
+    return value.replace(/[^A-Za-z0-9_-]/g, '-');
+}
+
+/**
+ * Return the element id, generating a stable one when it has none.
+ */
+function ensureId(element, prefix) {
+    if (!element.id) {
+        element.id = `${prefix}-${++sequence}`;
+    }
+
+    return element.id;
+}
+
+/**
+ * Collect the panels belonging to a labels container. Panels live outside of
+ * it - MaryUI teleports the labels into `#<uuid>-labels` while the panels stay
+ * in the sibling "original data" wrapper - so the search starts at the parent.
+ * Nested <x-tabs> render their own [x-data] root, which is used to discard
+ * panels owned by an inner group; the full list is kept as a fallback should
+ * that markup ever change upstream.
+ */
+function panelsFor(container) {
+    const scope = container.parentElement;
+
+    if (!scope) {
+        return [];
+    }
+
+    const root = container.closest('[x-data]');
+    const panels = Array.from(scope.querySelectorAll('.tab-content'));
+    const owned = root ? panels.filter((panel) => panel.closest('[x-data]') === root) : [];
+
+    return owned.length > 0 ? owned : panels;
+}
+
+/**
+ * The tabs reachable by keyboard: disabled and hidden ones are skipped.
+ */
+function navigableTabs(container) {
+    return Array.from(container.querySelectorAll('label.tab[role="tab"]')).filter(
+        (tab) => !tab.classList.contains('tab-disabled') && tab.offsetParent !== null
+    );
+}
+
+/**
+ * Mirror MaryUI's `tab-active` class into aria-selected and a roving tabindex.
+ * The class is the single source of truth - nothing here decides the selection.
+ */
+function syncState(container) {
+    const tabs = Array.from(container.querySelectorAll('label.tab[role="tab"]'));
+
+    if (tabs.length === 0) {
+        return;
+    }
+
+    let hasActive = false;
+
+    tabs.forEach((tab) => {
+        const active = tab.classList.contains('tab-active');
+
+        if (active) {
+            hasActive = true;
+        }
+
+        tab.setAttribute('aria-selected', active ? 'true' : 'false');
+        tab.setAttribute('tabindex', active ? '0' : '-1');
+    });
+
+    // Keep the tablist reachable with a single Tab stop even before Alpine has
+    // applied `tab-active`, or when the bound value matches no tab at all.
+    if (!hasActive) {
+        const first = navigableTabs(container)[0];
+
+        if (first) {
+            first.setAttribute('tabindex', '0');
+        }
+    }
+}
+
+/**
+ * Activate a tab through a real click, so MaryUI's Alpine @click handler stays
+ * the only writer of `selected`; focus then follows the activated tab.
+ */
+function activate(tab) {
+    if (!tab) {
+        return;
+    }
+
+    tab.click();
+    tab.focus();
+}
+
+/**
+ * Keyboard navigation, delegated from the tablist container.
+ */
+function onKeydown(event) {
+    if (!NAV_KEYS.includes(event.key)) {
+        return;
+    }
+
+    const container = event.currentTarget;
+    const target = event.target instanceof Element ? event.target : null;
+    const current = target ? target.closest('label.tab[role="tab"]') : null;
+
+    if (!current || !container.contains(current)) {
+        return;
+    }
+
+    const tabs = navigableTabs(container);
+    const index = tabs.indexOf(current);
+
+    if (index === -1) {
+        return;
+    }
+
+    event.preventDefault();
+
+    if (event.key === 'ArrowRight') {
+        activate(tabs[(index + 1) % tabs.length]);
+    } else if (event.key === 'ArrowLeft') {
+        activate(tabs[(index - 1 + tabs.length) % tabs.length]);
+    } else if (event.key === 'Home') {
+        activate(tabs[0]);
+    } else if (event.key === 'End') {
+        activate(tabs[tabs.length - 1]);
+    } else {
+        activate(current);
+    }
+}
+
+/**
+ * Apply the ARIA wiring to one labels container. Labels and panels are paired
+ * by NAME, never by index, so a hidden or reordered tab cannot desynchronise
+ * the mapping. Returns true when the container is one this module owns.
+ */
+function enhance(container) {
+    const labels = Array.from(container.querySelectorAll('label.tab'));
+
+    if (labels.length === 0) {
+        return false;
+    }
+
+    // Neutrality: leave already-operable tabs alone. Labels enhanced here are
+    // not counted, otherwise the module would opt out of its own work.
+    const alreadyOperable = labels.some(
+        (label) => !label.hasAttribute(TAB_FLAG) && isOperable(label)
+    );
+
+    if (alreadyOperable) {
+        return false;
+    }
+
+    const named = labels
+        .map((label) => ({ label, name: labelName(label) }))
+        .filter((tab) => tab.name !== null);
+
+    if (named.length === 0) {
+        return false;
+    }
+
+    const panelByName = new Map();
+
+    panelsFor(container).forEach((panel) => {
+        const name = panelName(panel);
+
+        if (name !== null && !panelByName.has(name)) {
+            panelByName.set(name, panel);
+        }
+    });
+
+    const containerId = ensureId(container, 'tabs-a11y');
+
+    container.setAttribute('role', 'tablist');
+    container.setAttribute('aria-orientation', 'horizontal');
+
+    named.forEach(({ label, name }) => {
+        const labelId = label.id || `${containerId}-tab-${idSafe(name)}`;
+
+        label.id = labelId;
+        label.setAttribute('role', 'tab');
+        label.setAttribute(TAB_FLAG, '');
+
+        if (label.classList.contains('tab-disabled')) {
+            label.setAttribute('aria-disabled', 'true');
+        } else {
+            label.removeAttribute('aria-disabled');
+        }
+
+        const panel = panelByName.get(name);
+
+        if (panel) {
+            const panelId = panel.id || `${containerId}-panel-${idSafe(name)}`;
+
+            panel.id = panelId;
+            panel.setAttribute('role', 'tabpanel');
+            panel.setAttribute('aria-labelledby', labelId);
+            panel.setAttribute(PANEL_FLAG, '');
+            label.setAttribute('aria-controls', panelId);
+        }
+    });
+
+    syncState(container);
+
+    return true;
+}
+
+/**
+ * Scan the document and enhance every tabs container found. Attribute writes
+ * are idempotent, so this is safe to run on every DOM change; listeners and
+ * observers are attached once per container.
+ */
+function enhanceAll() {
+    document.querySelectorAll('.tabs').forEach((container) => {
+        if (!enhance(container)) {
+            return;
+        }
+
+        if (container.hasAttribute(CONTAINER_FLAG)) {
+            return;
+        }
+
+        container.setAttribute(CONTAINER_FLAG, '');
+        container.addEventListener('keydown', onKeydown);
+
+        // MaryUI toggles `tab-active` on the labels; mirror it back into ARIA.
+        // Only `class` is watched, and this module never writes classes, so
+        // the observer cannot re-trigger itself.
+        new MutationObserver(() => syncState(container)).observe(container, {
+            attributes: true,
+            attributeFilter: ['class'],
+            subtree: true,
+        });
+    });
+}
+
+let scheduled = false;
+
+/**
+ * Coalesce bursts of DOM mutations into a single pass per animation frame.
+ */
+function schedule() {
+    if (scheduled) {
+        return;
+    }
+
+    scheduled = true;
+
+    requestAnimationFrame(() => {
+        scheduled = false;
+        enhanceAll();
+    });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', schedule);
+} else {
+    schedule();
+}
+
+// The labels are teleported after Alpine boots, and Livewire can re-render
+// both labels and panels, so the pass has to run again on SPA navigation and
+// on any DOM insertion. Only childList is observed at this level: watching
+// attributes here would loop on this module's own ARIA writes.
+document.addEventListener('livewire:navigated', schedule);
+
+new MutationObserver(schedule).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+});


### PR DESCRIPTION
## Summary

Restores keyboard navigation and screen reader support for MaryUI tabs (>= 2.9.9), which lost accessibility when the component was refactored to use `x-teleport` and removed the hidden radio inputs that previously provided ARIA semantics.

## Changes

- **New module: `resources/js/tabs-a11y.js`** — A non-invasive accessibility shim that:
  - Applies WAI-ARIA tabs pattern (`role=tablist`, `role=tab`, `role=tabpanel`) to rendered markup
  - Wires `id` and `aria-*` attributes between labels and panels by matching tab names from Alpine expressions
  - Derives `aria-selected` and roving `tabindex` from MaryUI's existing `tab-active` class (no duplication of state)
  - Implements keyboard navigation: `ArrowLeft`/`ArrowRight` (cycle tabs), `Home`/`End` (jump to first/last), `Enter`/`Space` (activate)
  - Activates tabs via `label.click()` so MaryUI's Alpine handler remains the sole owner of selection state
  - Observes DOM mutations and `tab-active` class changes to keep ARIA state in sync
  - Gracefully skips tabs that are already keyboard-operable (MaryUI <= 2.9.8 or future upstream fixes)

- **Updated `resources/js/app.js`** — Imports the new accessibility module at startup

## Implementation Details

- **Non-invasive**: No patching of vendor components, Blade views, or CSS; no class or visual changes
- **Idempotent**: Safe to run on every DOM change; listeners and observers attached once per container
- **Coalesced**: Bursts of mutations are coalesced into a single pass per animation frame
- **Scope-aware**: Nested `<x-tabs>` are handled correctly by matching panels to their owning `[x-data]` root
- **Robust**: Tab names are parsed from Alpine expressions and paired with panels by name (not index), so hidden or reordered tabs cannot desynchronize the mapping
- **Livewire-compatible**: Responds to `livewire:navigated` events and DOM insertions to re-enhance after SPA navigation or re-renders

Fixes keyboard and screen reader access to tabs without requiring upstream changes or user configuration.

https://claude.ai/code/session_01NkYEbAktwJigUeZwQqGHMh