### PR TITLE
chore(deps): upgrade Livewire to v4.4.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2563,16 +2563,16 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v4.3.5",
+            "version": "v4.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "7ef4b2a876c71744e86463079dd506b26eeab624"
+                "reference": "514b29d5a23594d4e4846494f580268b20c2f11e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/7ef4b2a876c71744e86463079dd506b26eeab624",
-                "reference": "7ef4b2a876c71744e86463079dd506b26eeab624",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/514b29d5a23594d4e4846494f580268b20c2f11e",
+                "reference": "514b29d5a23594d4e4846494f580268b20c2f11e",
                 "shasum": ""
             },
             "require": {
@@ -2627,7 +2627,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v4.3.5"
+                "source": "https://github.com/livewire/livewire/tree/v4.4.0"
             },
             "funding": [
                 {
@@ -2635,7 +2635,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-03T04:09:44+00:00"
+            "time": "2026-08-10T15:24:22+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -10540,5 +10540,5 @@
         "php": "^8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Bumps livewire/livewire v4.3.5 -> v4.4.0 (lock only; the existing
"^4.0" constraint already allows it). No other package changed.

Reviewed the release for anything blocking — nothing is:

- #10475 (component named "Index" resolving to an empty name) only
  reorders namespace-stripping vs ".index"-stripping in the Finder, so
  it changes root-level index components. This repo's only index page
  is nested (pages::protected.admin.index) and is unaffected: it still
  resolves and renders, and route:list is byte-identical.
- #10492 / #10502 / #10513 (.live debounce/throttle, batched renderless
  calls, stale live model responses) are fixes that benefit the eight
  wire:model.live[.debounce] bindings in the admin pages; no API change.
- #10499 / #10446 / #10510 / #10393 touch renderless setup, lifecycle
  hooks, #[Authorize] and a new test assertion — none of which this repo
  uses.
- Alpine 3.16.0 ships bundled in livewire.js (verified in the served
  asset). No breaking changes; the store fixes do not affect
  theme-store.js, and x-anchor-fix.js / tabs-a11y.js are unaffected.

Verification (LARAVEL13_MIGRATION.md checklist) on PHP 8.4.19 /
Laravel 13.24.0:

- php artisan test: green
- route:list: identical to the v4.3.5 baseline (46 routes)
- schedule:list: 2 tasks, unchanged
- optimize / optimize:clear: config, events, routes, views, blade-icons
  all cacheable
- npm run build: succeeds; CSS output byte-identical to v4.3.5
  (app-BaKYf9e8.css, 333.95 kB) when built against a warm view cache
- pint --test --dirty: passes
- HTTP smoke test: all 37 static GET routes match the v4.3.5 baseline
- Livewire runtime: pages::home and pages::protected.admin.index render;
  wire:model.live round-trips on the tours, virtual-airlines and manage
  admin pages

Pre-existing and out of scope: /mary/spotlight returns 500 because
MaryUI's default config points at App\Support\Spotlight, which has never
existed in this repo (config/mary.php is unpublished). Unrelated to
Livewire and unchanged by this bump.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ELeCxhwrTw1anVfCBBvN9a